### PR TITLE
Improve support for user-trained PARM models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ pre_trained_models/SuRE-prom-enh.parm
 example_data_output*
 test_fold*
 output_fold*
+AGS_fold*

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ slurm_out/
 pre_trained_models/SuRE-prom-enh.parm
 example_data_output*
 test_fold*
+output_fold*

--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,6 @@ slurm_out/
 pre_trained_models/SuRE-prom-enh.parm
 example_data_output*
 test_fold*
-output_fold*
+output*
 AGS_fold*
+AGS_my*

--- a/PARM/PARM_train.py
+++ b/PARM/PARM_train.py
@@ -514,7 +514,7 @@ def validation_loop(
     val_loss /= batch_ndx
 
     # Plot the predicted vs. measurements for this validation epoch
-    fig, ax = plt.subplots(figsize=(6, 6))
+    fig, ax = plt.subplots(figsize=(5, 5))
     ax.hist2d(
         y_val_predicted.flatten(),
         y_val_real.flatten(),
@@ -526,7 +526,7 @@ def validation_loop(
     ax.set_xlabel("Predicted Log2RPM")
     ax.set_ylabel("Measured Log2RPM")
     ax.set_title(f"Validation epoch {this_epoch} - {cell_type} cell type")
-    plt.savefig(os.path.join(output_directory, f"validation_scatter_{this_epoch}.png"))
+    plt.savefig(os.path.join(output_directory, f"validation_scatter_{this_epoch}.svg"))
     
     return (y_val_predicted, y_val_real, val_loss)
 

--- a/PARM/PARM_train.py
+++ b/PARM/PARM_train.py
@@ -58,10 +58,6 @@ def PARM_train(args):
     
     log(f"Cuda working? {torch.cuda.is_available()}")
 
-    log(f"Output directory: {output_directory}")
-
-    log(f"Input Directory {input_directory}")
-
     # Check if validation data is in training data
     error = any(
         file_validation in input_directory for file_validation in validation_path
@@ -523,7 +519,7 @@ def validation_loop(
         y_val_predicted.flatten(),
         y_val_real.flatten(),
         bins=(100,100),
-        norm=colors.LogNorm()
+        norm=colors.LogNorm(),
         cmap="viridis",
     )
     corrfunc(y_val_predicted.flatten(), y_val_real.flatten(), ax=ax)

--- a/PARM/PARM_train.py
+++ b/PARM/PARM_train.py
@@ -44,7 +44,6 @@ def PARM_train(args):
         sys.exit(
             f"Error: Wrong values of betas. You must provide two values, you provided {len(betas)}"
         )
-
     #############
     # 3. Create output directory
 

--- a/PARM/PARM_utils_data_loader.py
+++ b/PARM/PARM_utils_data_loader.py
@@ -187,7 +187,7 @@ class h5_dataset(torch.utils.data.Dataset):
         self.file_path = path
         self.dataset = None
         self.celltype = celltype
-        self.Zscore_logTPM = 'LnNorm'
+        self.Zscore_logTPM = 'Log2RPM'
         
         # Check if multiple cell types
         self.multiple_cells = self.celltype.split("__")

--- a/PARM/__main__.py
+++ b/PARM/__main__.py
@@ -113,8 +113,6 @@ def train(args):
 
 
 def predict(args):
-    # Check input fasta
-    check_sequence_length(args.input, args.L_max)
     # Implement the logic for the predict command here
     print(description)
     print("=" * 80)
@@ -126,6 +124,9 @@ def predict(args):
     print_arguments("Number of batches", args.n_seqs_per_batch)
     print_arguments("Show only sequence's header in the output file?", args.header_only)
     print_arguments("Model filter size ", args.filter_size)
+    print_arguments("Loss function type", args.type_loss)
+    print_arguments("L_max", args.L_max)
+    print_arguments("Predict test fold?", args.predict_test_fold)
     # Same but now filling the output with spaces so it gets 80 characters
     print("=" * 80)
     PARM_predict(
@@ -135,7 +136,9 @@ def predict(args):
         n_seqs_per_batch=args.n_seqs_per_batch,
         store_sequence=not args.header_only,
         filter_size= args.filter_size,
-        type_loss=args.type_loss
+        type_loss=args.type_loss,
+        L_max=args.L_max,
+        test_fold = args.predict_test_fold
     )
 
 
@@ -418,6 +421,15 @@ def predict_subparser(subparsers):
 
     advanced_args = group.add_argument_group("Advanced arguments (if you trained your own model)")
 
+    advanced_args.add_argument(
+        "--predict_test_fold",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="If this flag is set, PARM will assume the input is the hdf5 file of the "
+        "test fold of a trained model. This is useful if you want to evaluate the "
+        "performance of a model that you trained. "
+    )
+        
     advanced_args.add_argument(
         "--L_max",
         type=int,

--- a/PARM/version.py
+++ b/PARM/version.py
@@ -1,4 +1,4 @@
 # Writing the version in a separated file to make it easier to access.
 # Thanks again Ryan Wick for the inspiring way of coding
 # https://github.com/rrwick/Trycycler/tree/main/trycycler
-__version__ = '0.1.2'
+__version__ = '0.1.4'

--- a/PARM/version.py
+++ b/PARM/version.py
@@ -1,4 +1,4 @@
 # Writing the version in a separated file to make it easier to access.
 # Thanks again Ryan Wick for the inspiring way of coding
 # https://github.com/rrwick/Trycycler/tree/main/trycycler
-__version__ = '0.1.0'
+__version__ = '0.1.1'

--- a/PARM/version.py
+++ b/PARM/version.py
@@ -1,4 +1,4 @@
 # Writing the version in a separated file to make it easier to access.
 # Thanks again Ryan Wick for the inspiring way of coding
 # https://github.com/rrwick/Trycycler/tree/main/trycycler
-__version__ = '0.1.7'
+__version__ = '0.1.8'

--- a/PARM/version.py
+++ b/PARM/version.py
@@ -1,4 +1,4 @@
 # Writing the version in a separated file to make it easier to access.
 # Thanks again Ryan Wick for the inspiring way of coding
 # https://github.com/rrwick/Trycycler/tree/main/trycycler
-__version__ = '0.1.1'
+__version__ = '0.1.2'

--- a/PARM/version.py
+++ b/PARM/version.py
@@ -1,4 +1,4 @@
 # Writing the version in a separated file to make it easier to access.
 # Thanks again Ryan Wick for the inspiring way of coding
 # https://github.com/rrwick/Trycycler/tree/main/trycycler
-__version__ = '0.1.8'
+__version__ = '0.1.27'

--- a/PARM/version.py
+++ b/PARM/version.py
@@ -1,4 +1,4 @@
 # Writing the version in a separated file to make it easier to access.
 # Thanks again Ryan Wick for the inspiring way of coding
 # https://github.com/rrwick/Trycycler/tree/main/trycycler
-__version__ = '0.1.4'
+__version__ = '0.1.7'

--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
-# Table of contents
+## Table of contents
 
-- [**Introduction**](#introduction)
-- [**Installation**](#installation)
-- [**Quick usage examples**](#quick-usage-examples)
-  * [Predicting promoter activity](#predicting-promoter-activity)
-  * [Running _in-silico_ mutagenesis](#running-in-silico-mutagenesis)
-  * [Plotting results of _in-silico_ mutagenesis](#plotting-results-of-in-silico-mutagenesis)
+- [Table of contents](#table-of-contents)
+- [Introduction](#introduction)
+- [Installation](#installation)
+- [Usage examples](#usage-examples)
+  - [Predicting promoter activity](#predicting-promoter-activity)
+- [Running _in-silico_ mutagenesis](#running-in-silico-mutagenesis)
+- [Plotting results of _in-silico_ mutagenesis](#plotting-results-of-in-silico-mutagenesis)
+  - [Training your own PARM model](#training-your-own-parm-model)
+  - [Making predictions with your own model](#making-predictions-with-your-own-model)
+    - [Considerations for training your model](#considerations-for-training-your-model)
 
-# Introduction
+## Introduction
 
 PARM (Promoter Activity Regulatory Model) is a deep learning model that predicts the promoter activity from the DNA sequence itself.
 As a convolution neural network trained on MPRA data, **PARM** is very lightweight and produces predictions in a cell-type-specific manner.
@@ -17,7 +21,7 @@ With the `PARM predict` tool, you can get predictions for any sequence that you 
 With `PARM mutagenesis`, in addition to simple promoter activity scores, **PARM** can also produce the so-called _in-silico_ mutagenesis plot.
 This is useful for predicting which TFs are regulating (activating or repressing) your sequence. (read more on [Running _in-silico_ mutagenesis](#running-in-silico-mutagenesis)).
 
-# Installation
+## Installation
 
 **PARM** can be easily installed with `conda`:
 
@@ -25,9 +29,9 @@ This is useful for predicting which TFs are regulating (activating or repressing
 conda install -c anaconda -c conda-forge -c bioconda -c pytorch parm
 ```
 
-# Usage examples
+## Usage examples
 
-## Predicting promoter activity
+### Predicting promoter activity
 
 To predict the promoter activity in K562 of every sequence in a fasta file, run:
 
@@ -35,32 +39,24 @@ To predict the promoter activity in K562 of every sequence in a fasta file, run:
 parm predict \
   --input example_data/input.fasta \
   --output output_K562.txt \
-  --model pre_trained_models/K562.parm
+  --model pre_trained_models/K562/
 ```
 
-> Note that you should replace `pre_trained_models/K562.parm` with the actual path to the pre-trained models available on this page.
-
-To perform predictions for more than one cell, you can simply provide all the paths separated by space:
-
-```sh
-parm predict \
-  --input example_data/input.fasta \
-  --output output_K562_HepG2_LNCaP.txt \
-  --model pre_trained_models/K562.parm pre_trained_models/HepG2.parm pre_trained_models/LNCaP.parm
-```
+> Note that you should replace `pre_trained_models/K562/` with the actual path to the pre-trained models available on this page.
+> Also, note that a PARM model is composed of five different folds, as each model is trained five times. If you check the content of `pre_trained_models/K562/`,
+> you will see the `.parm` files there, one for each fold. Do not rename or change the files there unless you know what you are doing.
 
 The output is a tab-separated file. 
 The first and second columns contain information about the sequence (the sequence and its header).
-The following column contains the predicted promoter activity for the model you have selected. 
-If you performed predictions for more than one cell, more than one column will be created here.
+The following column contains the predicted promoter activity for the model you have selected.
 
 For the command line above, you should expect the following result:
 
-| sequence    | header                           | prediction_K562   | prediction_HepG2   | prediction_LNCaP    |
-|-------------|----------------------------------|-------------------|--------------------|---------------------|
-| CTGGGAGG... | CXCR4_chr2:136875708:136875939:- | 2.287095785140991 | 1.4889564514160156 | 0.2345067262649536  |
-| GCAACTAA... | MED16_chr19:893131:893362:-      | 2.22406268119812  | 2.6182565689086914 | 0.30299943685531616 |
-| ACGCCCAG... | TERT_chr5:1295135:1295366:-      | 1.993780255317688 | 1.474591612815857  | 0.11847741901874542 |
+| sequence    | header                           | prediction_K562   |
+|-------------|----------------------------------|-------------------|
+| CTGGGAGG... | CXCR4_chr2:136875708:136875939:- | 2.287095785140991 |
+| GCAACTAA... | MED16_chr19:893131:893362:-      | 2.22406268119812  |
+| ACGCCCAG... | TERT_chr5:1295135:1295366:-      | 1.993780255317688 |
 
 
 ## Running _in-silico_ mutagenesis
@@ -71,16 +67,7 @@ To compute the _in-silico_ mutagenesis for every sequence in a fasta file, run:
 parm mutagenesis \
   --input example_data/input.fasta \
   --output in_silico_mutagenesis_K562 \
-  --model pre_trained_models/K562.parm
-```
-
-You can also run `PARM mutagenesis` for more than one cell:
-
-```sh
-parm mutagenesis \
-  --input input.fasta \
-  --output in_silico_mutagenesis_K562_HepG2_LNCaP \
-  --model pre_trained_models/K562.parm pre_trained_models/HepG2.parm pre_trained_models/LNCaP.parm
+  --model pre_trained_models/K562/
 ```
 
 For every sequence in the input fasta, **PARM** will predict the effect of every possible mutation of every single base pair.
@@ -108,5 +95,107 @@ parm plot \
 This will read the mutagenesis matrix and the hits for the sequence `sequence_of_interest` and generate the plot.
 By default, **PARM** stored the result plot as a PDF inside the input dir.
 This can be changed using optional arguments. 
+
 Run `parm plot --help` for additional help on that.
 
+### Training your own PARM model
+
+If you want to train a PARM model with your MPRA data, you must pre-process the raw MPRA counts using our [pre-processing pipeline](https://github.com/vansteensellab/PARM_preprocessing_pipeline).
+This will produce, mainly, one-hot encoded files with the promoter activity per fragment, per cell. 
+In the `example_data/training_data` directory, we provide an example of this for the AGS and HAP1 cells.
+
+We always train PARM models five independent times, using different folds (splits of the data) for validation.  
+To train the PARM models for the AGS cell, you can run:
+
+```sh
+# Fold 0 model
+parm train \
+  --input example_data/training_data/onehot/fold[1234].* \
+  --validation example_data/training_data/onehot/fold0.hdf5 \
+  --output AGS_fold0 \
+  --cell_type AGS
+```
+
+This will create the `AGS_fold0` folder, with the following structure:
+
+```
+AGS_fold0/
+├── AGS_fold0.parm
+├── performance_stats/
+|   ├── loss_per_epoch.png
+|   ├── loss_per_epoch.txt
+│   ├── validation_scatter_0.svg
+│   ├── validation_scatter_1.svg
+│   |-- ...one per epoch
+│   └── validation_scatter_6.svg
+└── temp_models/ 
+    ├── model_epoch_0.pth
+    ├── model_epoch_1.pth
+    |-- ...one per epoch
+    └── model_epoch_6.pth
+```
+
+In this case, `AGS_fold0.parm` is the main result.
+In the `performance_stats` dir, you will find the training and validation loss of each training epoch ( `loss_per_epoch.*` files), as well as the scatter plot of the measured vs. predicted Log2RPM values for each epoch (`validation_scatter_*.svg` files).
+In the `temp_models` dir, you can find the intermediate models for each training epoch (`temp_models` dir).
+
+Similarly, for the other folds, you can run:
+
+```sh
+# Fold 1 model
+parm train \
+  --input example_data/training_data/onehot/fold[0234].* \
+  --validation example_data/training_data/onehot/fold1.hdf5 \
+  --output AGS_fold1 \
+  --cell_type AGS
+
+# Fold 2 model
+parm train \
+  --input example_data/training_data/onehot/fold[0134].* \
+  --validation example_data/training_data/onehot/fold2.hdf5 \
+  --output AGS_fold2 \
+  --cell_type AGS
+
+# Fold 3 model
+parm train \
+  --input example_data/training_data/onehot/fold[0124].* \
+  --validation example_data/training_data/onehot/fold3.hdf5 \
+  --output AGS_fold3 \
+  --cell_type AGS
+
+# Fold 4 model
+parm train \
+  --input example_data/training_data/onehot/fold[0123].* \
+  --validation example_data/training_data/onehot/fold4.hdf5 \
+  --output AGS_fold4 \
+  --cell_type AGS
+```
+
+### Making predictions with your own model
+
+After training all the folds, you should place all the folds in a single directory:
+
+```sh
+mkdir my_AGS_model
+cp AGS_fold0/AGS_fold0.parm \
+   AGS_fold1/AGS_fold1.parm \
+   AGS_fold2/AGS_fold2.parm \
+   AGS_fold3/AGS_fold3.parm \
+   AGS_fold4/AGS_fold4.parm \
+   my_AGS_model/
+```
+
+and then, run:
+
+```sh
+parm predict \
+  --input example_data/input.fasta \
+  --output output_my_AGS.txt \
+  --model my_AGS_model/
+```
+
+#### Considerations for training your model
+
+- The provided data in the `example_data/training_data` is not enough to train a good PARM model. We only provide it here for the sake of this tutorial.
+- Always run the `PARM train` function from a GPU server. A normal CPU machine will take a long time to train a model, even the provided example data. In the start of the training, PARM will print in the screen if a GPU is detected. Make sure that you see `GPU detected? True`.
+- Even if your input data contains measurements for more than one cell (as the provided example, that contains data for AGS and HAP1), you can only train a model for one cell at a time.


### PR DESCRIPTION
This pull request improves the support for user-trained PARM models.

### Key changes:
* Organised output directories in `PARM_train.py` by creating subfolders (`temp_models` and `performance_stats`) for temporary model files and performance metrics, respectively. 
* Enhanced validation loop in `PARM_train.py` to generate and save scatter plots showing predicted vs. measured values for each validation epoch. 
* Change the filename of the output model. Now, it follows the basename of the output directory.
* Added support for test fold predictions in `PARM_predict.py` (via `--predict_test_fold` argument), allowing evaluation of trained models using HDF5 test fold data. This includes generating measured vs. predicted plots and calculating Pearson correlation coefficients.
* Add instructions on the README on how to train the models.