### PR TITLE
Update README.md to use an env, remove anaconda, and clarify __cuda

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,15 @@ This is useful for predicting which TFs are regulating (activating or repressing
 **PARM** can be easily installed with `conda`:
 
 ```sh
-conda install -c anaconda -c conda-forge -c bioconda -c pytorch parm
+conda install -n parm-env -c conda-forge -c bioconda -c pytorch parm
+```
+
+Note: this package can benefit from GPU acceleration using CUDA. Ensure that the [virtual package](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-virtual.html) `__cuda` is present using `conda info` or use `CONDA_OVERRIDE_CUDA=<version>` to specify CUDA version.
+
+To use the package, activate the environment using:
+
+```sh
+conda activate parm-env
 ```
 
 ## Usage examples


### PR DESCRIPTION
Hello!
In this PR I propose a small tweak to the installation instructions after running into and issue and helping a user at my organization.

First of all, I add `-n parm-env` to ensure a virtual environment is created and used. Otherwise users may install into `base` which is highly discouraged.
Second, mixing anaconda and conda-forge is not recommended because of potential binary incompatibility, see also
https://conda-forge.org/docs/user/transitioning_from_defaults/
As of 2024, bioconda no longer uses `defaults` and is fully compatible with conda-forge
Additionally, anaconda channels require licensing and can be blocked at many organizations.

Finally, I add a note about leveraging GPU acceleration via the __cuda virtual package.
